### PR TITLE
Redesign CLI around explicit --toml/--py version sources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.10'
           - '3.11'
           - '3.12'
           - '3.13'
@@ -96,7 +95,7 @@ jobs:
           github.event_name == 'push' &&
           startsWith(github.ref, 'refs/tags')
         run: |
-          uv run vercheck $GITHUB_REF_NAME src/vercheck/about.py
+          uv run vercheck $GITHUB_REF_NAME --py=src/vercheck/about.py
 
   test-publish:
     if: >-

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 *.egg-info/
 *.py[co]
 /build/
+/.complexipy_cache/
+/.vscode/
+/coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Replaced the positional `filename` argument with explicit, mutually
+  exclusive `--toml` and `--py` flags. `--toml` auto-detects
+  `pyproject.toml`/`Cargo.toml` in the current directory when given no
+  value, or reads an explicit `file[:dotted.key.path]` otherwise
+  (repeatable; when more than one source resolves, all versions must
+  agree). `--py` checks a Python module's `__version__` attribute.
+- `version` is now an optional positional argument. Omitting it checks
+  only the resolved `--toml`/`--py` source's PEP-440 compliance, with
+  no comparison — this replaces the old `--check-version-number-only`
+  flag.
+- Raised the minimum supported Python version to 3.11, to use the
+  standard library's `tomllib` for TOML parsing instead of adding a
+  runtime dependency.
+
+### Removed
+
+- Dropped support for reading a version from a `*.egg-info/PKG-INFO`
+  file. Use `--toml` (for `pyproject.toml`/`Cargo.toml`) or `--py` (for
+  a Python module's `__version__`) instead.
+- Removed the `--check-version-number-only` flag; omit the `version`
+  argument for the same effect.
+
+## [0.2.0] - 2024-10-11
+
+### Added
+
+- Support for checking a version against a Python module's
+  `__version__` attribute.
+
+### Changed
+
+- Improved error handling when extracting a version from a file.
+
+## [0.1.0] - 2024-10-09
+
+### Added
+
+- Initial release: check a version number for PEP-440 compliance, and
+  optionally compare it against a version read from a
+  `*.egg-info/PKG-INFO` file.
+
+[unreleased]: https://github.com/cleder/vercheck/compare/0.2.0...HEAD
+[0.2.0]: https://github.com/cleder/vercheck/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/cleder/vercheck/releases/tag/0.1.0

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,35 @@
+# Vercheck
+
+A command-line tool that validates a version string is PEP-440 compliant and, optionally, that it agrees with the version declared in a project's manifest files.
+
+## Language
+
+**Target version**:
+The version string the user is asserting is correct — passed as the optional positional CLI argument. When present, it is checked against one or more resolved sources. When absent, only the resolved source's own version is checked for compliance.
+_Avoid_: tag name, version argument
+
+**Version source**:
+A place a version string is read from: a TOML manifest (`--toml`) or a Python module's `__version__` (`--py`). Exactly one kind of source may be used per invocation — `--toml` and `--py` are mutually exclusive.
+
+**Compliance-only mode**:
+Invocation with no Target version. Only checks that the resolved source's version (or, with no source at all, none — not a valid combination) is PEP-440 compliant. No cross-comparison is performed.
+_Avoid_: check-version-number-only (old flag name, being retired)
+
+**Comparison mode**:
+Invocation with a Target version given. The Target version must itself be PEP-440 compliant, each resolved source version must be PEP-440 compliant, and all of them must be equal to each other.
+
+**Auto-detect mode**:
+Triggered by bare `--toml` (no value). Looks in the current directory for known manifest files (`pyproject.toml`, `Cargo.toml`) and checks whichever are present. If more than one is present, their versions must match each other (and the Target version, if given).
+
+**Explicit mode**:
+Triggered by `--toml=path` given one or more times. Checks exactly the named file(s) and performs no auto-detection. If more than one is given, their versions must match each other (and the Target version, if given).
+
+**Key path**:
+A dot-delimited address into a TOML file's table structure identifying where the version string lives, e.g. `tool.poetry.version`. Given inline in explicit mode as `file:dotted.key.path` (colon-separated from the filename). Auto-detect mode always uses the built-in default for each manifest kind — there is no way to override the key path without naming the file explicitly.
+_Avoid_: attr, module attribute (that's a `--py` concept, not a `--toml` one)
+
+**Manifest default key path**:
+The key path used when no override is given: `project.version` for `pyproject.toml`, `package.version` for `Cargo.toml`. `--toml` only ever reads a literal string value at a key path — it never imports or resolves Python module attributes (that indirection is `--py`'s job).
+
+**Mismatch report**:
+The single error produced when the set of resolved versions (Target version, if given, plus every source's version) contains more than one distinct value. Lists each contributing source alongside the version it produced, rather than one error per pairwise disagreement.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vercheck
 
-Check if a version number is PEP-440 compliant and optionally compare it against a version specified in a python file or the PKG-INFO metadata file.
+Check if a version number is PEP-440 compliant and optionally compare it against a version declared in a TOML manifest (`pyproject.toml`, `Cargo.toml`, or any other `file:key.path`) or a Python module's `__version__` attribute.
 
 
 [![PyPI](https://img.shields.io/pypi/v/vercheck.svg)][pypi status]
@@ -52,6 +52,26 @@ dynamic = "version"
 attr = "mypkg.about.__version__"
 ```
 
+The recommended way to implement that `__version__` attribute is to read it back from your package's own installed metadata, rather than hard-coding a second copy of the version string:
+
+```python
+from importlib.metadata import version
+
+__version__ = version("mypkg")
+```
+
+This way there is exactly one source of truth — whatever your build backend wrote into `pyproject.toml` at build time — and `vercheck 0.2.0 --py=src/mypkg/about.py` still works unchanged, since `--py` only cares that the module exposes a `__version__` string.
+
+If you use [Poetry](https://python-poetry.org/) instead, the version lives at `tool.poetry.version` rather than `project.version`:
+
+```toml
+[tool.poetry]
+name = "mypkg"
+version = "0.2.0"
+```
+
+Check it with `vercheck 0.2.0 --toml=pyproject.toml:tool.poetry.version` — see the [Usage](#usage) examples below.
+
 When you release a new version of your package, checking the version number is a good practice.
 You can automate this in your CI/CD pipeline, for example, using [GitHub Actions](https://docs.github.com/en/actions).
 
@@ -62,14 +82,14 @@ You can automate this in your CI/CD pipeline, for example, using [GitHub Actions
           startsWith(github.ref, 'refs/tags')
         run: |
           pip install vercheck
-          vercheck $GITHUB_REF_NAME src/vercheck/about.py
+          vercheck $GITHUB_REF_NAME --py=src/vercheck/about.py
 ```
 
 This will check that your tag name is a valid version number and that the version number in the `src/vercheck/about.py` file is the same as the tag name.
 
 ## Requirements
 
-- Python >= 3.10, no dependencies outside of the standard library.
+- Python >= 3.11, no dependencies outside of the standard library.
 
 ## Installation
 
@@ -84,55 +104,68 @@ $ pip install vercheck
 to get a quick overview of the available commands and options, you can use the `vercheck -h` command.
 
 ```console
-usage: vercheck [-h] [--check-version-number-only] version [filename]
+usage: vercheck [-h] [--toml [FILE[:KEY.PATH]]] [--py FILE] [version]
 
-Check if the version is PEP-440 conformant.
+Check if a version is PEP-440 compliant.
 
 positional arguments:
-  version               The version number to compare against.
-  filename              The path to the file containing the version information.
+  version               The version number to check. If omitted, only the
+                         resolved --toml/--py source is checked for PEP-440
+                         compliance.
 
 options:
-  -h, --help            show this help message and exit
-  --check-version-number-only
-                        Only check if the version number is PEP-440 compliant without trying to retrieve a version from a file.
+  -h, --help             show this help message and exit
+  --toml [FILE[:KEY.PATH]]
+                         Check the version in a TOML manifest. With no value,
+                         auto-detects 'pyproject.toml'/'Cargo.toml' in the
+                         current directory; if more than one is found, they
+                         must agree. With a value, checks exactly that file
+                         (default key path 'project.version'/'package.version',
+                         or 'file:dotted.key.path' to override). Repeatable.
+  --py FILE              Check the __version__ attribute of a Python module.
 ```
 
-`vercheck` will exit with a non-zero exit code if the version number is not PEP-440 compliant, the file path does not exist or the version number is not equal to the version number in the file.
+`vercheck` will exit with a non-zero exit code if any resolved version is not PEP-440 compliant, a given file/key path does not exist, or the resolved versions do not all agree.
+
+`--toml` and `--py` are mutually exclusive. Put `version` before `--toml`/`--py` on the command line — argparse otherwise swallows the next token as the flag's value.
 
 Examples:
 
 ```bash
-vercheck 0.2.0 src/vercheck/about.py
+vercheck 0.2.0
 ```
 
-This will check if the version number is PEP-440 compliant and if the version number is equal to the version number in the `src/vercheck/about.py` file.
-It does not provide any output if the version number is PEP-440 compliant and the version number is equal to the version number in the file. If an error is encountered, it will print the error message and exit with a non-zero exit code.
+Just checks that `0.2.0` is PEP-440 compliant. No comparison, no output on success.
 
 ```bash
-vercheck 0.2.0 --check-version-number-only
+vercheck 0.2.0 --toml
 ```
 
-This will check if the version number is PEP-440 compliant without trying to retrieve a version from a file.
+Checks `0.2.0` against whichever of `pyproject.toml`/`Cargo.toml` are present in the current directory (all of them, if more than one exists — they must agree with each other and with `0.2.0`).
 
 ```bash
-vercheck 0.2.0 src
+vercheck --toml
 ```
 
-or
+Checks that the auto-detected manifest's own version is PEP-440 compliant (and that multiple manifests, if present, agree with each other) — no literal version to compare against.
 
 ```bash
-vercheck 0.2.0 src/vercheck.egg-info/PKG-INFO
+vercheck 0.2.0 --toml=Cargo.toml
 ```
 
-This will check if the version number is PEP-440 compliant and if the version number is equal to the version number in the `src/vercheck.egg-info/PKG-INFO` file.
-The output will be:
+Checks `0.2.0` against exactly `Cargo.toml`'s `package.version`, skipping auto-detection.
 
-```console
-Warning: filename src does not end with '.py'
-Checking version in src
-Found 'src/vercheck.egg-info'
+```bash
+vercheck 0.2.0 --toml=pyproject.toml:tool.poetry.version
 ```
+
+Checks `0.2.0` against a Poetry-style `pyproject.toml`, where the version lives at `tool.poetry.version` instead of the setuptools-style `project.version` default. `--toml` never resolves setuptools `dynamic`/`attr` indirection — for that, point `--py` at the Python module directly.
+
+```bash
+vercheck 0.2.0 --py=src/package/about.py
+```
+
+Checks `0.2.0` against the `__version__` attribute defined in `src/package/about.py`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ options:
   --py FILE              Check the __version__ attribute of a Python module.
 ```
 
+> **Order matters:** always put `version` before `--toml`/`--py` — argparse otherwise
+> swallows the next token as the flag's value (e.g. `vercheck --toml 0.1.0` treats
+> `0.1.0` as the TOML spec, not the version to check).
+
 `vercheck` will exit with a non-zero exit code if any resolved version is not PEP-440 compliant, a given file/key path does not exist, or the resolved versions do not all agree.
 
-`--toml` and `--py` are mutually exclusive. Put `version` before `--toml`/`--py` on the command line — argparse otherwise swallows the next token as the flag's value.
+`--toml` and `--py` are mutually exclusive.
 
 Examples:
 

--- a/docs/adr/0001-cli-v2-simplified-version-sources.md
+++ b/docs/adr/0001-cli-v2-simplified-version-sources.md
@@ -1,0 +1,18 @@
+# CLI v2: replace positional filename with `--toml`/`--py` version sources, drop egg-info support, bump Python floor to 3.11+
+
+**Status**: accepted
+
+The original CLI took a required `version` positional plus an optional positional `filename` that vercheck sniffed (`.py` → `__version__`, anything else → `*.egg-info/PKG-INFO`'s `Version:` line) to decide how to read a comparison version. This guessing was confusing and PKG-INFO/egg-info is a build artifact, not a source of truth developers actually edit.
+
+We replaced it with explicit, mutually exclusive `--toml`/`--py` flags, made the `version` positional itself optional (its absence now means "just check the resolved source for PEP-440 compliance," replacing the separate `--check-version-number-only` flag), and dropped egg-info/PKG-INFO reading entirely.
+
+`--toml` also gained auto-detection (bare `--toml` checks whichever of `pyproject.toml`/`Cargo.toml` exist in the cwd, requiring them to agree) and an explicit `file:dotted.key.path` form for non-default manifests (e.g. Poetry's `tool.poetry.version`). It intentionally never resolves setuptools' `dynamic`/`attr` indirection — that's what `--py` is for — to keep `--toml` a pure "read a literal string at a key path" operation.
+
+Reading TOML for real (not just the previously-unsupported case) requires a real parser for both `pyproject.toml` and `Cargo.toml`. `tomllib` is stdlib only from Python 3.11+; adding `tomli` as a runtime dependency would break the tool's "no dependencies outside the standard library" property. We chose to bump the minimum supported Python to 3.11+ rather than take the dependency, since this is a CLI tool (not a library people pin transitively) and 3.10 support was the more reversible cost.
+
+This is a breaking change to the CLI surface and warrants a major version bump.
+
+## Considered Options
+
+- Auto-resolve setuptools `dynamic`/`attr` inside `--toml` — rejected to keep `--toml` free of Python-import side effects; users on dynamic setuptools versioning use `--py` directly.
+- Add `tomli` as a runtime dependency to keep Python 3.10 support — rejected in favor of preserving the zero-dependency property.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -23,7 +22,7 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
-description = "Check if a version number is PEP-440 compliant and optionally compare it against a version specified in a python file or the PKG-INFO metadata file."
+description = "Check if a version number is PEP-440 compliant and optionally compare it against a version declared in a TOML manifest or a python file."
 dynamic = [
     "version",
 ]
@@ -33,7 +32,7 @@ keywords = [
     "introspection",
 ]
 name = "vercheck"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.license]
 text = "MIT"
@@ -132,7 +131,7 @@ exclude = [
     "tests/data",
 ]
 fix = true
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 ignore = [

--- a/src/vercheck/vercheck.py
+++ b/src/vercheck/vercheck.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Check if a version number is PEP-440 compliant.
 
-Optionally compare it against a version specified in a python file or the PKG-INFO
-metadata file.
+Optionally compare it against a version declared in a TOML manifest
+(``pyproject.toml``, ``Cargo.toml``, or any other TOML file with an explicit
+key path) or a Python module's ``__version__`` attribute.
 
 """
 
 import argparse
 import re
 import sys
+import tomllib
 from importlib.util import module_from_spec
 from importlib.util import spec_from_file_location
 from pathlib import Path
@@ -21,34 +23,25 @@ pattern: Final = (
     r"(\.dev(?P<dev>\d+))?)?$"
 )
 
+AUTO_DETECT: Final = "__AUTO_DETECT__"
 
-def guess_file_name(path: Path) -> Path:
-    """Guesses the file name of the PKG-INFO file within an .egg-info directory.
+DEFAULT_KEY_PATHS: Final[dict[str, tuple[str, ...]]] = {
+    "pyproject.toml": ("project", "version"),
+    "Cargo.toml": ("package", "version"),
+}
 
-    This function searches for directories with the .egg-info extension in the current
-    directory. If such a directory is found, it returns the path to the PKG-INFO file
-    within that directory.
-    If no .egg-info directory is found, it writes an error message to stdout and
-    exits the program with a status code of 1.
+KEY_PATH_RE: Final = re.compile(
+    r"^(?P<file>.+):(?P<key>[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+)$",
+)
 
-    Returns:
-        Path: The path to the PKG-INFO file within the found .egg-info directory.
 
-    Raises:
-        SystemExit: If no .egg-info directory is found.
-
-    """
-    """"""
-    egg_info_dirs = list(path.glob("*.egg-info"))
-    if egg_info_dirs:
-        sys.stdout.write(f"Found '{egg_info_dirs[0]}'\n")
-        return egg_info_dirs[0] / "PKG-INFO"
-    sys.stderr.write("No filename provided and no '*.egg-info' directory found\n")
-    return Path()
+def check_version(version: str) -> bool:
+    """Check if the version is PEP-440 compliant."""
+    return bool(re.match(pattern, version))
 
 
 def get_version_from_module(file_name: Path) -> str:
-    """Get the version from the module."""
+    """Get the version from a Python module's __version__ attribute."""
     spec = spec_from_file_location("module.name", file_name)
     if spec is None:
         sys.stderr.write(f"Error loading file '{file_name}'")
@@ -71,71 +64,125 @@ def get_version_from_module(file_name: Path) -> str:
         sys.exit(1)
 
 
-def get_version_from_pkg_info(file_path: Path) -> str:
-    """Get the version from the file."""
-    if file_path.is_dir():
-        file_path = guess_file_name(file_path)
+def parse_toml_spec(spec: str) -> tuple[Path, tuple[str, ...]]:
+    """Split a ``--toml`` value into a file path and a key path.
+
+    ``file:dotted.key.path`` gives an explicit key path; otherwise the
+    manifest's built-in default key path (keyed by file name) is used.
+    """
+    match = KEY_PATH_RE.match(spec)
+    if match:
+        return Path(match["file"]), tuple(match["key"].split("."))
+    file_path = Path(spec)
+    default = DEFAULT_KEY_PATHS.get(file_path.name)
+    if default is None:
+        sys.stderr.write(
+            f"Error: no default key path known for '{file_path.name}', "
+            f"use '{spec}:dotted.key.path' to specify one\n",
+        )
+        sys.exit(1)
+    return file_path, default
+
+
+def get_version_from_toml(file_path: Path, key_path: tuple[str, ...]) -> str:
+    """Get the version string at key_path within a TOML file."""
+    dotted = ".".join(key_path)
     try:
-        with file_path.open("r") as f:
-            for line in f:
-                if line.startswith("Version:"):
-                    sys.stdout.write(f"Found 'Version:' in '{file_path}'\n")
-                    return line.split(":")[1].strip()
-    except (FileNotFoundError, IsADirectoryError) as e:
-        sys.stderr.write(f"Error loading file '{file_path}': {e}\n")
-        return ""
-    sys.stderr.write(f"No Version found in '{file_path}'\n")
-    return ""
+        with file_path.open("rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        sys.stderr.write(f"Error: '{file_path}' does not exist\n")
+        sys.exit(1)
+    except tomllib.TOMLDecodeError as e:
+        sys.stderr.write(f"Error parsing '{file_path}': {e}\n")
+        sys.exit(1)
+    node: object = data
+    for key in key_path:
+        if not isinstance(node, dict) or key not in node:
+            sys.stderr.write(f"Error: '{dotted}' not found in '{file_path}'\n")
+            sys.exit(1)
+        node = node[key]
+    if not isinstance(node, str):
+        sys.stderr.write(f"Error: '{dotted}' in '{file_path}' is not a string\n")
+        sys.exit(1)
+    return node
 
 
-def get_version_from_file(file_name: str) -> str:
-    """Get the version from the filename file."""
-    file_path = Path(file_name)
-    if file_name.endswith(".py"):
-        return get_version_from_module(file_path)
-    sys.stdout.write(f"Warning: filename {file_name} does not end with '.py'\n")
-    sys.stdout.write(f"Checking version in '{file_name or '*.egg-info/PKG-INFO'}'\n")
-    return get_version_from_pkg_info(file_path)
+def autodetect_toml_files() -> list[Path]:
+    """Find the known manifest files present in the current directory."""
+    found = [Path(name) for name in DEFAULT_KEY_PATHS if Path(name).is_file()]
+    if not found:
+        names = " or ".join(DEFAULT_KEY_PATHS)
+        sys.stderr.write(
+            f"Error: --toml given with no value and no {names} "
+            "found in the current directory\n",
+        )
+        sys.exit(1)
+    return found
 
 
-def check_version(version: str) -> bool:
-    """Check if the version is PEP-440 compliant."""
-    return bool(re.match(pattern, version))
+def resolve_toml_sources(toml_specs: list[str]) -> list[tuple[str, str]]:
+    """Resolve --toml specs to (label, version) pairs."""
+    if AUTO_DETECT in toml_specs:
+        if len(toml_specs) > 1:
+            sys.stderr.write(
+                "Error: --toml cannot be combined with --toml=<file>\n",
+            )
+            sys.exit(1)
+        sources = [
+            (file_path, DEFAULT_KEY_PATHS[file_path.name])
+            for file_path in autodetect_toml_files()
+        ]
+    else:
+        sources = [parse_toml_spec(spec) for spec in toml_specs]
+    return [
+        (str(file_path), get_version_from_toml(file_path, key_path))
+        for file_path, key_path in sources
+    ]
 
 
-def check_versions(version: str, tag_name: str) -> list[str]:
-    """Check if the version in the filename file matches the given version."""
-    errors = []
-    if version != tag_name:
-        errors.append(f"Version '{version}' does not match tag '{tag_name}'")
-    if not check_version(tag_name):
-        errors.append(f"Tag name '{tag_name}' is not PEP-440 compliant")
-    if not check_version(version):
-        errors.append(f"Version '{version}' is not PEP-440 compliant")
+def check_versions(resolved: list[tuple[str, str]]) -> list[str]:
+    """Check every resolved version is PEP-440 compliant and all agree."""
+    errors = [
+        f"'{version}' ({label}) is not PEP-440 compliant"
+        for label, version in resolved
+        if not check_version(version)
+    ]
+    if len({version for _, version in resolved}) > 1:
+        details = ", ".join(f"{label}: {version}" for label, version in resolved)
+        errors.append(f"Versions do not match: {details}")
     return errors
 
 
-def check_version_number_only(version: str) -> int:
-    """Check if the version number is PEP-440 compliant."""
-    if not check_version(version):
-        sys.stderr.write(f"Tag name '{version}' is not PEP-440 compliant\n")
+def collect_resolved(
+    version: str | None,
+    toml_specs: list[str] | None,
+    py_path: str | None,
+) -> list[tuple[str, str]]:
+    """Gather the given version and every resolved source's version."""
+    resolved: list[tuple[str, str]] = []
+    if version is not None:
+        resolved.append(("the given version", version))
+    if toml_specs:
+        resolved.extend(resolve_toml_sources(toml_specs))
+    if py_path:
+        resolved.append((py_path, get_version_from_module(Path(py_path))))
+    return resolved
+
+
+def check(
+    version: str | None,
+    toml_specs: list[str] | None,
+    py_path: str | None,
+) -> int:
+    """Check version compliance and, if a source is given, agreement with it."""
+    if toml_specs and py_path:
+        sys.stderr.write("Error: --toml and --py are mutually exclusive\n")
         return 1
-    sys.stdout.write(f"Tag name '{version}' is PEP-440 compliant\n")
-    return 0
-
-
-def check(tag_name: str, file_name: str, *, check_only: bool) -> int:
-    """Check if the version in the filename file matches the given version."""
-    if check_only:
-        if file_name:
-            sys.stderr.write(
-                "Error: --check-version-number-only "
-                "can only be used without a filename\n",
-            )
-            return 1
-        return check_version_number_only(tag_name)
-    version = get_version_from_file(file_name)
-    errors = check_versions(version, tag_name)
+    if version is None and not toml_specs and not py_path:
+        sys.stderr.write("Error: nothing to check: give a version, --toml, or --py\n")
+        return 1
+    errors = check_versions(collect_resolved(version, toml_specs, py_path))
     if errors:
         for error in errors:
             sys.stderr.write(f"Error: {error}\n")
@@ -144,34 +191,46 @@ def check(tag_name: str, file_name: str, *, check_only: bool) -> int:
 
 
 def main() -> None:
-    """Check if the version in the filename file matches the given version."""
+    """Parse arguments and run the check."""
     parser = argparse.ArgumentParser(
-        description=("Check if the version is PEP-440 conformant."),
+        description="Check if a version is PEP-440 compliant.",
     )
-    parser.add_argument("version", help="The version number to compare against.")
     parser.add_argument(
-        "filename",
+        "version",
         nargs="?",
-        default="",
-        help="The path to the file containing the version information.",
+        default=None,
+        help=(
+            "The version number to check. If omitted, only the resolved "
+            "--toml/--py source is checked for PEP-440 compliance."
+        ),
     )
     parser.add_argument(
-        "--check-version-number-only",
-        action="store_true",
+        "--toml",
+        action="append",
+        nargs="?",
+        const=AUTO_DETECT,
+        default=None,
+        metavar="FILE[:KEY.PATH]",
         help=(
-            "Only check if the version number is PEP-440 compliant "
-            "without trying to retrieve a version from a file."
+            "Check the version in a TOML manifest. With no value, "
+            "auto-detects 'pyproject.toml'/'Cargo.toml' in the current "
+            "directory; if more than one is found, they must agree. "
+            "With a value, checks exactly that file (default key path "
+            "'project.version'/'package.version', or 'file:dotted.key.path' "
+            "to override). Repeatable; put 'version' before --toml to avoid "
+            "argparse swallowing it as --toml's value."
         ),
+    )
+    parser.add_argument(
+        "--py",
+        default=None,
+        metavar="FILE",
+        help="Check the __version__ attribute of a Python module.",
     )
 
     args = parser.parse_args()
 
-    exit_code = check(
-        args.version,
-        args.filename,
-        check_only=args.check_version_number_only,
-    )  # pragma: no cover
-    sys.exit(exit_code)  # pragma: no cover
+    sys.exit(check(args.version, args.toml, args.py))
 
 
 if __name__ == "__main__":

--- a/src/vercheck/vercheck.py
+++ b/src/vercheck/vercheck.py
@@ -23,7 +23,14 @@ pattern: Final = (
     r"(\.dev(?P<dev>\d+))?)?$"
 )
 
-AUTO_DETECT: Final = "__AUTO_DETECT__"
+
+class _AutoDetect:
+    """Sentinel marking a bare ``--toml`` (auto-detect mode)."""
+
+
+AUTO_DETECT: Final = _AutoDetect()
+
+TomlSpec = str | _AutoDetect
 
 DEFAULT_KEY_PATHS: Final[dict[str, tuple[str, ...]]] = {
     "pyproject.toml": ("project", "version"),
@@ -31,7 +38,7 @@ DEFAULT_KEY_PATHS: Final[dict[str, tuple[str, ...]]] = {
 }
 
 KEY_PATH_RE: Final = re.compile(
-    r"^(?P<file>.+):(?P<key>[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+)$",
+    r"^(?P<file>.+):(?P<key>[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*)$",
 )
 
 
@@ -43,24 +50,23 @@ def check_version(version: str) -> bool:
 def get_version_from_module(file_name: Path) -> str:
     """Get the version from a Python module's __version__ attribute."""
     spec = spec_from_file_location("module.name", file_name)
-    if spec is None:
-        sys.stderr.write(f"Error loading file '{file_name}'")
+    if spec is None or spec.loader is None:
+        sys.stderr.write(f"Error loading file '{file_name}'\n")
         sys.exit(1)
     module = module_from_spec(spec)
-    assert spec.loader is not None  # noqa: S101
     try:
         spec.loader.exec_module(module)
     except (FileNotFoundError, ImportError, SyntaxError) as e:
-        sys.stderr.write(f"Error loading file '{file_name}': {e}")
+        sys.stderr.write(f"Error loading file '{file_name}': {e}\n")
         sys.exit(1)
     try:
         version = module.__version__
         if not isinstance(version, str):
-            sys.stderr.write(f"Version in '{file_name}' is not a string")
+            sys.stderr.write(f"Version in '{file_name}' is not a string\n")
             sys.exit(1)
         return cast("str", module.__version__)
     except AttributeError:
-        sys.stderr.write(f"Module '{file_name}' has no __version__ attribute")
+        sys.stderr.write(f"Module '{file_name}' has no __version__ attribute\n")
         sys.exit(1)
 
 
@@ -90,8 +96,8 @@ def get_version_from_toml(file_path: Path, key_path: tuple[str, ...]) -> str:
     try:
         with file_path.open("rb") as f:
             data = tomllib.load(f)
-    except FileNotFoundError:
-        sys.stderr.write(f"Error: '{file_path}' does not exist\n")
+    except OSError as e:
+        sys.stderr.write(f"Error: '{file_path}' could not be read: {e}\n")
         sys.exit(1)
     except tomllib.TOMLDecodeError as e:
         sys.stderr.write(f"Error parsing '{file_path}': {e}\n")
@@ -121,10 +127,10 @@ def autodetect_toml_files() -> list[Path]:
     return found
 
 
-def resolve_toml_sources(toml_specs: list[str]) -> list[tuple[str, str]]:
+def resolve_toml_sources(toml_specs: list[TomlSpec]) -> list[tuple[str, str]]:
     """Resolve --toml specs to (label, version) pairs."""
     if AUTO_DETECT in toml_specs:
-        if len(toml_specs) > 1:
+        if any(spec != AUTO_DETECT for spec in toml_specs):
             sys.stderr.write(
                 "Error: --toml cannot be combined with --toml=<file>\n",
             )
@@ -134,7 +140,9 @@ def resolve_toml_sources(toml_specs: list[str]) -> list[tuple[str, str]]:
             for file_path in autodetect_toml_files()
         ]
     else:
-        sources = [parse_toml_spec(spec) for spec in toml_specs]
+        sources = [
+            parse_toml_spec(spec) for spec in toml_specs if isinstance(spec, str)
+        ]
     return [
         (str(file_path), get_version_from_toml(file_path, key_path))
         for file_path, key_path in sources
@@ -156,7 +164,7 @@ def check_versions(resolved: list[tuple[str, str]]) -> list[str]:
 
 def collect_resolved(
     version: str | None,
-    toml_specs: list[str] | None,
+    toml_specs: list[TomlSpec] | None,
     py_path: str | None,
 ) -> list[tuple[str, str]]:
     """Gather the given version and every resolved source's version."""
@@ -172,7 +180,7 @@ def collect_resolved(
 
 def check(
     version: str | None,
-    toml_specs: list[str] | None,
+    toml_specs: list[TomlSpec] | None,
     py_path: str | None,
 ) -> int:
     """Check version compliance and, if a source is given, agreement with it."""
@@ -186,7 +194,7 @@ def check(
     if errors:
         for error in errors:
             sys.stderr.write(f"Error: {error}\n")
-        return len(errors)
+        return min(len(errors), 255)
     return 0
 
 

--- a/tests/data/BAD-PKG-INFO
+++ b/tests/data/BAD-PKG-INFO
@@ -1,1 +1,0 @@
-Version: 0.1.0.alpha.2

--- a/tests/data/EMPTY-PKG-INFO
+++ b/tests/data/EMPTY-PKG-INFO
@@ -1,1 +1,0 @@
-Metadata-Version: 2.1

--- a/tests/data/pkg.egg-info/PKG-INFO
+++ b/tests/data/pkg.egg-info/PKG-INFO
@@ -1,6 +1,0 @@
-Metadata-Version: 2.1
-Name: vercheck
-Version: 0.1.0
-Summary: Vercheck
-Author-email: Christian Ledermann <christian.ledermann@gmail.com>
-License: MIT

--- a/tests/data/toml/Cargo.toml
+++ b/tests/data/toml/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/autodetect_both_match/Cargo.toml
+++ b/tests/data/toml/autodetect_both_match/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/autodetect_both_match/pyproject.toml
+++ b/tests/data/toml/autodetect_both_match/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/autodetect_both_mismatch/Cargo.toml
+++ b/tests/data/toml/autodetect_both_mismatch/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "sample"
+version = "0.2.0"

--- a/tests/data/toml/autodetect_both_mismatch/pyproject.toml
+++ b/tests/data/toml/autodetect_both_mismatch/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/autodetect_single/pyproject.toml
+++ b/tests/data/toml/autodetect_single/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/dynamic_pyproject.toml
+++ b/tests/data/toml/dynamic_pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "sample"
+dynamic = ["version"]
+
+[tool.setuptools.dynamic.version]
+attr = "sample.about.__version__"

--- a/tests/data/toml/malformed.toml.invalid
+++ b/tests/data/toml/malformed.toml.invalid
@@ -1,0 +1,2 @@
+[project
+name = "sample"

--- a/tests/data/toml/non_dict_intermediate.toml
+++ b/tests/data/toml/non_dict_intermediate.toml
@@ -1,0 +1,1 @@
+project = "not-a-table"

--- a/tests/data/toml/non_string_version.toml
+++ b/tests/data/toml/non_string_version.toml
@@ -1,0 +1,3 @@
+[project]
+name = "sample"
+version = 1

--- a/tests/data/toml/poetry.toml
+++ b/tests/data/toml/poetry.toml
@@ -1,0 +1,3 @@
+[tool.poetry]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/pyproject.toml
+++ b/tests/data/toml/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/top_level_version.toml
+++ b/tests/data/toml/top_level_version.toml
@@ -1,0 +1,2 @@
+name = "sample"
+version = "0.1.0"

--- a/tests/data/toml/unrecognized_name.toml
+++ b/tests/data/toml/unrecognized_name.toml
@@ -1,0 +1,2 @@
+[project]
+version = "0.1.0"

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -119,6 +119,15 @@ def test_parse_toml_spec_explicit_key_path() -> None:
     assert key_path == ("tool", "poetry", "version")
 
 
+def test_parse_toml_spec_single_segment_key_path() -> None:
+    """A single-segment (undotted) explicit key path is accepted."""
+    file_path, key_path = vercheck.parse_toml_spec(
+        f"{TOML_DIR / 'top_level_version.toml'}:version",
+    )
+    assert file_path == TOML_DIR / "top_level_version.toml"
+    assert key_path == ("version",)
+
+
 def test_parse_toml_spec_unrecognized_name_without_key_path() -> None:
     """A file with no built-in default and no override key path errors."""
     with pytest.raises(SystemExit) as excinfo:
@@ -147,6 +156,13 @@ def test_get_version_from_toml_file_not_found() -> None:
             TOML_DIR / "does-not-exist.toml",
             ("project", "version"),
         )
+    assert excinfo.value.code == 1
+
+
+def test_get_version_from_toml_directory() -> None:
+    """Error (not an unhandled traceback) when the path is a directory."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_toml(TOML_DIR, ("project", "version"))
     assert excinfo.value.code == 1
 
 
@@ -220,6 +236,17 @@ def test_resolve_toml_sources_autodetect_both_match(
     monkeypatch.chdir(TOML_DIR / "autodetect_both_match")
     resolved = vercheck.resolve_toml_sources([vercheck.AUTO_DETECT])
     assert dict(resolved) == {"pyproject.toml": "0.1.0", "Cargo.toml": "0.1.0"}
+
+
+def test_resolve_toml_sources_repeated_bare_toml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeating bare --toml still auto-detects, it is not "combined with explicit"."""
+    monkeypatch.chdir(TOML_DIR / "autodetect_single")
+    resolved = vercheck.resolve_toml_sources(
+        [vercheck.AUTO_DETECT, vercheck.AUTO_DETECT],
+    )
+    assert resolved == [("pyproject.toml", "0.1.0")]
 
 
 def test_resolve_toml_sources_autodetect_combined_with_explicit() -> None:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,157 +7,11 @@ import pytest
 from vercheck import vercheck
 
 TEST_DIR = pathlib.Path(__file__).parent
+DATA_DIR = TEST_DIR / "data"
+TOML_DIR = DATA_DIR / "toml"
 
 
-def test_check_succeeds() -> None:
-    """Check returns a status code of zero."""
-    assert vercheck.check("0.1.0", str(TEST_DIR / "data"), check_only=False) == 0
-
-
-def test_check_with_flag_succeeds() -> None:
-    """Check returns a status code of zero."""
-    assert vercheck.check("0.1.0", "", check_only=True) == 0
-
-
-def test_check_with_flag_and_filename_fails() -> None:
-    """Check returns a status code of one."""
-    assert vercheck.check("0.1.0", str(TEST_DIR / "data"), check_only=True) == 1
-
-
-def test_check_file_succeeds() -> None:
-    """It exits with a status code of zero."""
-    assert (
-        vercheck.check(
-            "0.1.0",
-            str(TEST_DIR / "data" / "pkg.egg-info" / "PKG-INFO"),
-            check_only=False,
-        )
-        == 0
-    )
-
-
-def test_check_fails_with_wrong_version() -> None:
-    """It exits with a status code of one."""
-    assert vercheck.check("0.1.1", str(TEST_DIR / "data"), check_only=False) == 1
-
-
-def test_check_fails_with_wrong_tag_name() -> None:
-    """It exits with a status code of one."""
-    assert (
-        vercheck.check(
-            "0.1.0a",
-            str(TEST_DIR / "data" / "BAD-PKG-INFO"),
-            check_only=False,
-        )
-        == 3
-    )
-
-
-def test_check_fails_with_wrong_path() -> None:
-    """It exits with a status code of one."""
-    assert vercheck.check("0.1.0", str(TEST_DIR), check_only=False) == 2
-
-
-def test_check_fails_when_path_not_exist() -> None:
-    """It exits with a status code of one."""
-    assert vercheck.check("0.1.0", str(TEST_DIR / "not_exist"), check_only=False) == 2
-
-
-def test_check_fails_with_no_version() -> None:
-    """It exits with a status code of one."""
-    assert (
-        vercheck.check(
-            "0.1.0",
-            str(TEST_DIR / "data" / "EMPTY-PKG-INFO"),
-            check_only=False,
-        )
-        == 2
-    )
-
-
-def test_check_fails_with_no_filename() -> None:
-    """It exits with a status code of one."""
-    assert vercheck.check("0.1.0", "", check_only=False) == 2
-
-
-def test_args() -> None:
-    """It exits with a status code of zero."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.main()
-    assert isinstance(excinfo.value.code, int)
-    assert excinfo.value.code >= 2
-
-
-def test_get_version_from_pkg_info_empty() -> None:
-    """Get the version from the PKG-INFO file."""
-    assert (
-        vercheck.get_version_from_pkg_info(TEST_DIR / "data" / "EMPTY-PKG-INFO") == ""
-    )
-
-
-def test_module_version() -> None:
-    """Load a python module and get the version."""
-    assert vercheck.get_version_from_module(TEST_DIR / "data" / "about.py") == "0.1.0a1"
-
-
-def test_module_version_with_import_error() -> None:
-    """Load a python module and get the version."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.get_version_from_module(TEST_DIR / "data" / "import_error.py")
-    assert excinfo.value.code == 1
-
-
-def test_module_version_with_syntax_error() -> None:
-    """Load a python module and get the version."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.get_version_from_module(TEST_DIR / "data" / "syntax_error.py")
-    assert excinfo.value.code == 1
-
-
-def test_module_version_with_empty_file() -> None:
-    """Load a python module and get the version."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.get_version_from_module(TEST_DIR / "data" / "empty.py")
-    assert excinfo.value.code == 1
-
-
-def test_module_version_with_file_does_not_exist() -> None:
-    """Load a python module and get the version."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.get_version_from_module(TEST_DIR / "does" / "not" / "exist.py")
-    assert excinfo.value.code == 1
-
-
-def test_module_version_with_directory() -> None:
-    """Load a python module and get the version."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.get_version_from_module(TEST_DIR / "data")
-    assert excinfo.value.code == 1
-
-
-def test_check_python_module_with_version() -> None:
-    """Load a python module and check the version."""
-    assert (
-        vercheck.check("0.1.0a1", str(TEST_DIR / "data" / "about.py"), check_only=False)
-        == 0
-    )
-
-
-def test_check_version_number_only() -> None:
-    """Check if the version number is PEP-440 compliant."""
-    assert vercheck.check("0.1.0", "", check_only=True) == 0
-
-
-def test_check_version_number_only_fail() -> None:
-    """Check if the version number is PEP-440 compliant."""
-    assert vercheck.check("0.1.0a", "", check_only=True) == 1
-
-
-def test_get_version_from_module_float_version() -> None:
-    """Load a python module and get the version."""
-    with pytest.raises(SystemExit) as excinfo:
-        vercheck.get_version_from_module(TEST_DIR / "data" / "float_version.py")
-    assert excinfo.value.code == 1
+# -- check_version --------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -188,3 +42,322 @@ def test_check_version_success(version: str) -> None:
     More comprehensive tests are in hypothesis_test.py.
     """
     assert vercheck.check_version(version)
+
+
+# -- get_version_from_module ----------------------------------------------
+
+
+def test_module_version() -> None:
+    """Load a python module and get the version."""
+    assert vercheck.get_version_from_module(DATA_DIR / "about.py") == "0.1.0a1"
+
+
+def test_module_version_with_import_error() -> None:
+    """Load a python module and get the version."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_module(DATA_DIR / "import_error.py")
+    assert excinfo.value.code == 1
+
+
+def test_module_version_with_syntax_error() -> None:
+    """Load a python module and get the version."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_module(DATA_DIR / "syntax_error.py")
+    assert excinfo.value.code == 1
+
+
+def test_module_version_with_empty_file() -> None:
+    """Load a python module and get the version."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_module(DATA_DIR / "empty.py")
+    assert excinfo.value.code == 1
+
+
+def test_module_version_with_file_does_not_exist() -> None:
+    """Load a python module and get the version."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_module(TEST_DIR / "does" / "not" / "exist.py")
+    assert excinfo.value.code == 1
+
+
+def test_module_version_with_directory() -> None:
+    """Load a python module and get the version."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_module(DATA_DIR)
+    assert excinfo.value.code == 1
+
+
+def test_get_version_from_module_float_version() -> None:
+    """Load a python module and get the version."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_module(DATA_DIR / "float_version.py")
+    assert excinfo.value.code == 1
+
+
+# -- parse_toml_spec --------------------------------------------------------
+
+
+def test_parse_toml_spec_default_pyproject() -> None:
+    """A plain pyproject.toml path uses the built-in default key path."""
+    file_path, key_path = vercheck.parse_toml_spec(str(TOML_DIR / "pyproject.toml"))
+    assert file_path == TOML_DIR / "pyproject.toml"
+    assert key_path == ("project", "version")
+
+
+def test_parse_toml_spec_default_cargo() -> None:
+    """A plain Cargo.toml path uses the built-in default key path."""
+    _file_path, key_path = vercheck.parse_toml_spec(str(TOML_DIR / "Cargo.toml"))
+    assert key_path == ("package", "version")
+
+
+def test_parse_toml_spec_explicit_key_path() -> None:
+    """An explicit file:dotted.key.path overrides the default."""
+    file_path, key_path = vercheck.parse_toml_spec(
+        f"{TOML_DIR / 'poetry.toml'}:tool.poetry.version",
+    )
+    assert file_path == TOML_DIR / "poetry.toml"
+    assert key_path == ("tool", "poetry", "version")
+
+
+def test_parse_toml_spec_unrecognized_name_without_key_path() -> None:
+    """A file with no built-in default and no override key path errors."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.parse_toml_spec(str(TOML_DIR / "unrecognized_name.toml"))
+    assert excinfo.value.code == 1
+
+
+# -- get_version_from_toml --------------------------------------------------
+
+
+def test_get_version_from_toml_success() -> None:
+    """Read a version from a valid key path."""
+    assert (
+        vercheck.get_version_from_toml(
+            TOML_DIR / "pyproject.toml",
+            ("project", "version"),
+        )
+        == "0.1.0"
+    )
+
+
+def test_get_version_from_toml_file_not_found() -> None:
+    """Error when the toml file does not exist."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_toml(
+            TOML_DIR / "does-not-exist.toml",
+            ("project", "version"),
+        )
+    assert excinfo.value.code == 1
+
+
+def test_get_version_from_toml_malformed() -> None:
+    """Error when the toml file cannot be parsed."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_toml(
+            TOML_DIR / "malformed.toml.invalid",
+            ("project", "version"),
+        )
+    assert excinfo.value.code == 1
+
+
+def test_get_version_from_toml_key_not_found() -> None:
+    """Error when the key path is absent (e.g. a dynamic version)."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_toml(
+            TOML_DIR / "dynamic_pyproject.toml",
+            ("project", "version"),
+        )
+    assert excinfo.value.code == 1
+
+
+def test_get_version_from_toml_non_dict_intermediate() -> None:
+    """Error when a key path segment resolves to a non-table value."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_toml(
+            TOML_DIR / "non_dict_intermediate.toml",
+            ("project", "version"),
+        )
+    assert excinfo.value.code == 1
+
+
+def test_get_version_from_toml_non_string_value() -> None:
+    """Error when the resolved value is not a string."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.get_version_from_toml(
+            TOML_DIR / "non_string_version.toml",
+            ("project", "version"),
+        )
+    assert excinfo.value.code == 1
+
+
+# -- autodetect_toml_files / resolve_toml_sources ---------------------------
+
+
+def test_autodetect_toml_files_none_found(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Error when no known manifest is present in the cwd."""
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.autodetect_toml_files()
+    assert excinfo.value.code == 1
+
+
+def test_resolve_toml_sources_autodetect_single(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-detect finds the one manifest present."""
+    monkeypatch.chdir(TOML_DIR / "autodetect_single")
+    resolved = vercheck.resolve_toml_sources([vercheck.AUTO_DETECT])
+    assert resolved == [("pyproject.toml", "0.1.0")]
+
+
+def test_resolve_toml_sources_autodetect_both_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-detect finds both manifests and their versions agree."""
+    monkeypatch.chdir(TOML_DIR / "autodetect_both_match")
+    resolved = vercheck.resolve_toml_sources([vercheck.AUTO_DETECT])
+    assert dict(resolved) == {"pyproject.toml": "0.1.0", "Cargo.toml": "0.1.0"}
+
+
+def test_resolve_toml_sources_autodetect_combined_with_explicit() -> None:
+    """Combining bare --toml with an explicit --toml=file is an error."""
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.resolve_toml_sources([vercheck.AUTO_DETECT, "Cargo.toml"])
+    assert excinfo.value.code == 1
+
+
+def test_resolve_toml_sources_explicit_multiple() -> None:
+    """Explicit mode resolves every given file."""
+    resolved = vercheck.resolve_toml_sources(
+        [str(TOML_DIR / "pyproject.toml"), str(TOML_DIR / "Cargo.toml")],
+    )
+    assert dict(resolved) == {
+        str(TOML_DIR / "pyproject.toml"): "0.1.0",
+        str(TOML_DIR / "Cargo.toml"): "0.1.0",
+    }
+
+
+# -- check_versions ----------------------------------------------------------
+
+
+def test_check_versions_all_compliant_and_matching() -> None:
+    """No errors when everything is compliant and matches."""
+    assert vercheck.check_versions([("a", "0.1.0"), ("b", "0.1.0")]) == []
+
+
+def test_check_versions_non_compliant() -> None:
+    """An error is reported for each non-compliant version."""
+    errors = vercheck.check_versions([("a", "not-a-version")])
+    assert len(errors) == 1
+    assert "not-a-version" in errors[0]
+
+
+def test_check_versions_mismatch() -> None:
+    """A single mismatch error lists every source and its version."""
+    errors = vercheck.check_versions([("a", "0.1.0"), ("b", "0.2.0")])
+    assert len(errors) == 1
+    assert "a: 0.1.0" in errors[0]
+    assert "b: 0.2.0" in errors[0]
+
+
+def test_check_versions_non_compliant_and_mismatch() -> None:
+    """Both a compliance error and a mismatch error can occur together."""
+    errors = vercheck.check_versions([("a", "not-a-version"), ("b", "0.2.0")])
+    assert len(errors) == 2
+
+
+# -- check --------------------------------------------------------------------
+
+
+def test_check_version_only_succeeds() -> None:
+    """A compliant literal version with no source succeeds."""
+    assert vercheck.check("0.1.0", None, None) == 0
+
+
+def test_check_version_only_fails() -> None:
+    """A non-compliant literal version with no source fails."""
+    assert vercheck.check("0.1.0a", None, None) == 1
+
+
+def test_check_nothing_given_fails() -> None:
+    """Nothing to check is an error."""
+    assert vercheck.check(None, None, None) == 1
+
+
+def test_check_toml_and_py_mutually_exclusive() -> None:
+    """--toml and --py cannot both be given."""
+    assert vercheck.check(None, [str(TOML_DIR / "pyproject.toml")], "some/file.py") == 1
+
+
+def test_check_toml_only_succeeds() -> None:
+    """--toml with no literal version checks the toml's own compliance."""
+    assert vercheck.check(None, [str(TOML_DIR / "pyproject.toml")], None) == 0
+
+
+def test_check_py_only_succeeds() -> None:
+    """--py with no literal version checks the module's own compliance."""
+    assert vercheck.check(None, None, str(DATA_DIR / "about.py")) == 0
+
+
+def test_check_version_matches_toml() -> None:
+    """A literal version matching the toml source succeeds."""
+    assert vercheck.check("0.1.0", [str(TOML_DIR / "pyproject.toml")], None) == 0
+
+
+def test_check_version_mismatches_toml() -> None:
+    """A literal version disagreeing with the toml source fails."""
+    assert vercheck.check("0.2.0", [str(TOML_DIR / "pyproject.toml")], None) == 1
+
+
+def test_check_version_matches_py() -> None:
+    """A literal version matching the py source succeeds."""
+    assert vercheck.check("0.1.0a1", None, str(DATA_DIR / "about.py")) == 0
+
+
+def test_check_version_mismatches_py() -> None:
+    """A literal version disagreeing with the py source fails."""
+    assert vercheck.check("0.1.0", None, str(DATA_DIR / "about.py")) == 1
+
+
+# -- main ---------------------------------------------------------------------
+
+
+def test_main_with_no_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare invocation with nothing to check exits with code 1."""
+    monkeypatch.setattr("sys.argv", ["vercheck"])
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.main()
+    assert excinfo.value.code == 1
+
+
+def test_main_with_compliant_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A compliant version on the CLI exits with code 0."""
+    monkeypatch.setattr("sys.argv", ["vercheck", "0.1.0"])
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.main()
+    assert excinfo.value.code == 0
+
+
+def test_main_with_toml(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--toml=file is parsed and checked end-to-end."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["vercheck", "0.1.0", f"--toml={TOML_DIR / 'pyproject.toml'}"],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.main()
+    assert excinfo.value.code == 0
+
+
+def test_main_with_py(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--py=file is parsed and checked end-to-end."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["vercheck", "0.1.0a1", f"--py={DATA_DIR / 'about.py'}"],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        vercheck.main()
+    assert excinfo.value.code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [[package]]
 name = "attrs"
@@ -17,10 +17,8 @@ version = "1.2.2.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701, upload-time = "2024-10-06T17:22:25.251Z" }
 wheels = [
@@ -51,21 +49,6 @@ version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz", hash = "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e", size = 106620, upload-time = "2024-10-09T07:40:20.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/8b/825cc84cf13a28bfbcba7c416ec22bf85a9584971be15b21dd8300c65b7f/charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4f9fc98dad6c2eaa32fc3af1417d95b5e3d08aff968df0cd320066def971f9a6", size = 196363, upload-time = "2024-10-09T07:38:02.622Z" },
-    { url = "https://files.pythonhosted.org/packages/23/81/d7eef6a99e42c77f444fdd7bc894b0ceca6c3a95c51239e74a722039521c/charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0de7b687289d3c1b3e8660d0741874abe7888100efe14bd0f9fd7141bcbda92b", size = 125639, upload-time = "2024-10-09T07:38:04.044Z" },
-    { url = "https://files.pythonhosted.org/packages/21/67/b4564d81f48042f520c948abac7079356e94b30cb8ffb22e747532cf469d/charset_normalizer-3.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ed2e36c3e9b4f21dd9422f6893dec0abf2cca553af509b10cd630f878d3eb99", size = 120451, upload-time = "2024-10-09T07:38:04.997Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/72/12a7f0943dd71fb5b4e7b55c41327ac0a1663046a868ee4d0d8e9c369b85/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d3ff7fc90b98c637bda91c89d51264a3dcf210cade3a2c6f838c7268d7a4ca", size = 140041, upload-time = "2024-10-09T07:38:06.676Z" },
-    { url = "https://files.pythonhosted.org/packages/67/56/fa28c2c3e31217c4c52158537a2cf5d98a6c1e89d31faf476c89391cd16b/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1110e22af8ca26b90bd6364fe4c763329b0ebf1ee213ba32b68c73de5752323d", size = 150333, upload-time = "2024-10-09T07:38:08.626Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/d2/466a9be1f32d89eb1554cf84073a5ed9262047acee1ab39cbaefc19635d2/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86f4e8cca779080f66ff4f191a685ced73d2f72d50216f7112185dc02b90b9b7", size = 142921, upload-time = "2024-10-09T07:38:10.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/01/344ec40cf5d85c1da3c1f57566c59e0c9b56bcc5566c08804a95a6cc8257/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f683ddc7eedd742e2889d2bfb96d69573fde1d92fcb811979cdb7165bb9c7d3", size = 144785, upload-time = "2024-10-09T07:38:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/73/8b/2102692cb6d7e9f03b9a33a710e0164cadfce312872e3efc7cfe22ed26b4/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27623ba66c183eca01bf9ff833875b459cad267aeeb044477fedac35e19ba907", size = 146631, upload-time = "2024-10-09T07:38:13.701Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/96/cc2c1b5d994119ce9f088a9a0c3ebd489d360a2eb058e2c8049f27092847/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f606a1881d2663630ea5b8ce2efe2111740df4b687bd78b34a8131baa007f79b", size = 140867, upload-time = "2024-10-09T07:38:15.403Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/27/cde291783715b8ec30a61c810d0120411844bc4c23b50189b81188b273db/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0b309d1747110feb25d7ed6b01afdec269c647d382c857ef4663bbe6ad95a912", size = 149273, upload-time = "2024-10-09T07:38:16.433Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/a4/8633b0fc1a2d1834d5393dafecce4a1cc56727bfd82b4dc18fc92f0d3cc3/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:136815f06a3ae311fae551c3df1f998a1ebd01ddd424aa5603a4336997629e95", size = 152437, upload-time = "2024-10-09T07:38:18.013Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ea/69af161062166b5975ccbb0961fd2384853190c70786f288684490913bf5/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:14215b71a762336254351b00ec720a8e85cada43b987da5a042e4ce3e82bd68e", size = 150087, upload-time = "2024-10-09T07:38:19.089Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/fd/e60a9d9fd967f4ad5a92810138192f825d77b4fa2a557990fd575a47695b/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79983512b108e4a164b9c8d34de3992f76d48cadc9554c9e60b43f308988aabe", size = 145142, upload-time = "2024-10-09T07:38:20.78Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/02/8cb0988a1e49ac9ce2eed1e07b77ff118f2923e9ebd0ede41ba85f2dcb04/charset_normalizer-3.4.0-cp310-cp310-win32.whl", hash = "sha256:c94057af19bc953643a33581844649a7fdab902624d2eb739738a30e2b3e60fc", size = 94701, upload-time = "2024-10-09T07:38:21.851Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/20/f1d4670a8a723c46be695dff449d86d6092916f9e99c53051954ee33a1bc/charset_normalizer-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:55f56e2ebd4e3bc50442fbc0888c9d8c94e4e06a933804e2af3e89e2f9c1c749", size = 102191, upload-time = "2024-10-09T07:38:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c", size = 193339, upload-time = "2024-10-09T07:38:24.527Z" },
     { url = "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944", size = 124366, upload-time = "2024-10-09T07:38:26.488Z" },
     { url = "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee", size = 118874, upload-time = "2024-10-09T07:38:28.115Z" },
@@ -145,16 +128,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/82/3128712a672e30a5fe76d484d72b09f31cb73e9dbc518bd9655fca934f9f/complexipy-5.2.0.tar.gz", hash = "sha256:3eee6916cf2acab5e247abfc75d09610b24fd370e45903810f1f33d20914e0c1", size = 301752, upload-time = "2026-01-28T19:23:09.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/f2/82366be420193b4b475c3039d40157a1eb24008c1cf3cb0cf1744566116d/complexipy-5.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ac0827d4b022e90dfe2165f9967e9f17415ca8b912dc3c94a9284e40d29c1b2", size = 2038835, upload-time = "2026-01-28T19:20:28.617Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/46/14d7fe87289cf0a3b93f5f598b81a8c634f810955098bea10534d62bc1b9/complexipy-5.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8437c232c438e930edad8dab1b524252dd5be38e8f047333ece4e2114c694fc9", size = 1949242, upload-time = "2026-01-28T19:20:30.541Z" },
-    { url = "https://files.pythonhosted.org/packages/13/04/49a89546cbdf316f91b90417a2bd8edb47ce772414d162f655d0322da6ac/complexipy-5.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:76e261d7ca31971d5f40b45f768a1f7fa2fba13bbaf02119da43f6505f14529f", size = 2113398, upload-time = "2026-01-28T19:20:32.186Z" },
-    { url = "https://files.pythonhosted.org/packages/03/b5/62cbb8d53e84cfd2770704123de297ec0cc0a21d6915388f6cef158ff8f1/complexipy-5.2.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:962b1ad8eade5da7f2cb78c3888f55eb754189e8c48a4380f0193eca48df6d34", size = 2046579, upload-time = "2026-01-28T19:20:33.806Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/81/40a5315291314c5d2610fcd7871ec52e84627321f9b5f93584286a6b5a72/complexipy-5.2.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:edfd62e022711ff8db11eebc8899d62696bbf88951a89c7db618491ee4e4f410", size = 2231599, upload-time = "2026-01-28T19:20:35.921Z" },
-    { url = "https://files.pythonhosted.org/packages/de/36/a311669590547b08fc428308abd0612d85cbf2851d92add08dbea3d8bc0d/complexipy-5.2.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7c109127b93df024cd7e7899ea59e94c5dbd40bc285c17898c3380fdb25730be", size = 2471846, upload-time = "2026-01-28T19:20:37.936Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/86/2a4ebf27325305a2183af9d87f56304e297e5cbd3019faafa0b65d63cf4d/complexipy-5.2.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d01fddf2a2100d744cb1f7d1b0c90046fc7005f3c9618367d006472ab6176ba5", size = 2255727, upload-time = "2026-01-28T19:20:40.658Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/bc/3b50ad5eefc09cf87ea5c6a23eea3d29436aeb7932016df953255fba980e/complexipy-5.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:760eb500387c36fcc6e31cba5257f33015b5ae31cf3612b0ac0722f96a556423", size = 2169928, upload-time = "2026-01-28T19:20:42.793Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/11/87b4d50b8455afb411fbb61a686d99bd1b1a8c9177629d09093663c1ef38/complexipy-5.2.0-cp310-cp310-win32.whl", hash = "sha256:62d6afdde276c053087a1a90448c3d3b06d8fa1b73f2c7c83706e280cabaac83", size = 1748092, upload-time = "2026-01-28T19:20:44.969Z" },
-    { url = "https://files.pythonhosted.org/packages/05/55/a5f7328d1787417c71b44dd252da0aea6b3ab82d8722eb8d7fac0b94580c/complexipy-5.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:3d130708edc0a4e26c6af99c489f37f44ee505ad76a4a7a483d92296eba1cc48", size = 1871613, upload-time = "2026-01-28T19:20:46.586Z" },
     { url = "https://files.pythonhosted.org/packages/8b/86/b6e3a6e955412a70134ee755ce7c8c817670adc735989722e109e2064afd/complexipy-5.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2bd19f5df57884e280c983d1c833c97a812971d7bc102afd6ee5ca0278d65994", size = 2038877, upload-time = "2026-01-28T19:20:48.225Z" },
     { url = "https://files.pythonhosted.org/packages/a0/bb/565c62d233cba3eec6d684bc8fde68d8c37ed3a5aed3b06953a258963d19/complexipy-5.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:214bb07249702188b7aa61d6ad9e0eb9cb1376ba520fb80c47aa49797e79a12c", size = 1949426, upload-time = "2026-01-28T19:20:49.861Z" },
     { url = "https://files.pythonhosted.org/packages/33/1b/301fbfae5f3b30efc8d39310785781532f90799c4d7e2cc6c7d09f9bd7f7/complexipy-5.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36608ef25bab118202a71f0c92eac06ed4d8add1bb191b21179ad986c0a812f7", size = 2113567, upload-time = "2026-01-28T19:20:51.552Z" },
@@ -195,10 +168,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/1e/ed1271ae9b99b65dd12a7ae0a8c298e1fe70ce00d58beb5d77f7581ea4e7/complexipy-5.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:238bb47723cfc77c999aa2ffb8182d49b74093538280129bec34a8f47e270226", size = 2168498, upload-time = "2026-01-28T19:21:54.025Z" },
     { url = "https://files.pythonhosted.org/packages/2f/09/4f6da93151b9b4d4f6a2a8a21aaafd117ed7aabde6f7871baf757d1fee56/complexipy-5.2.0-cp314-cp314-win32.whl", hash = "sha256:23da083d986cf880eccef8446269bd626ef025d327bb4e20a2bd557675989f77", size = 1746821, upload-time = "2026-01-28T19:21:55.722Z" },
     { url = "https://files.pythonhosted.org/packages/b9/52/251510b9b20eb79674bec668a52fe27b2384a3829d1585d1f05e0ac383a7/complexipy-5.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:fc7342f782edbe63e66197b25ce7716e8e6e6ab684c84c276977f5e2f797810a", size = 1872163, upload-time = "2026-01-28T19:21:57.436Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/0d/dec08bb3af52c3a672608b35d175e2655d9655519b51f4b04dc71f8e757f/complexipy-5.2.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:449578cc808a23506689c8c61186620c8072984563c3f2d687f0eaf0a4e41495", size = 2112682, upload-time = "2026-01-28T19:22:36.978Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9a/0cd4641b6b0bb00e6dad949f733efbccc342639c88682b902f4bec51d0f2/complexipy-5.2.0-pp310-pypy310_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:454bde3c7dffc3f9c0db1695b7cc62b85536b5100306a066fb27a5b96722dd02", size = 2047507, upload-time = "2026-01-28T19:22:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/db/35/8fc21644b1c48ab289069ce06998855498f28b18856b566a4f89cad00b37/complexipy-5.2.0-pp310-pypy310_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:abe7299d69c017d8026ff87b9fb1134c4dd3bdc8ffbbfb298075976f45a27881", size = 2471937, upload-time = "2026-01-28T19:22:40.418Z" },
-    { url = "https://files.pythonhosted.org/packages/37/70/589ec1ee8fe015d8bc064666e995e551f8952fdfe400286e548e19218563/complexipy-5.2.0-pp310-pypy310_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:16476d7852378b692ca46df4694c6109079f743abd03554bdc5522beb59caf00", size = 2255727, upload-time = "2026-01-28T19:22:42.242Z" },
     { url = "https://files.pythonhosted.org/packages/b7/a1/af0387fedd187ffa9dabcfeb324eec6c804e5da2c1ba96b570851ea4cec1/complexipy-5.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9a9255fae510ec134638220432c46f46493912d72d309e7f4b1f70fe75f4e666", size = 2112847, upload-time = "2026-01-28T19:22:43.889Z" },
     { url = "https://files.pythonhosted.org/packages/8f/31/c33f608b5d32e5df022ee6821530308d48a300f30e0be9af8a76d8740fc7/complexipy-5.2.0-pp311-pypy311_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:6520a2614d99f02fb429d83a6603fc1f620bac7f4caf71a4e4d962082676c44d", size = 2047577, upload-time = "2026-01-28T19:22:45.672Z" },
     { url = "https://files.pythonhosted.org/packages/8f/f8/de77c92adcea8bb0735317e27c1bb3e67cafd9f1a53ac158185d4b40b494/complexipy-5.2.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:93a5511cefe351a6a98f345768c0d4348b31c0aa4b5f108c0be323956becd352", size = 2232720, upload-time = "2026-01-28T19:22:47.317Z" },
@@ -213,16 +182,6 @@ version = "7.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/60/e781e8302e7b28f21ce06e30af077f856aa2cb4cf2253287dae9a593d509/coverage-7.6.2.tar.gz", hash = "sha256:a5f81e68aa62bc0cfca04f7b19eaa8f9c826b53fc82ab9e2121976dc74f131f3", size = 797872, upload-time = "2024-10-09T11:33:30.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/14/fb75c01b8427fb567c90ce920c90ed2bd314ad6960d54e8b377928607fd1/coverage-7.6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c9df1950fb92d49970cce38100d7e7293c84ed3606eaa16ea0b6bc27175bb667", size = 206561, upload-time = "2024-10-09T11:31:56.354Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b4/dcbf15f5583507415d0a78ce206e19d76699f1161e8b1ff6e1a21e9f9743/coverage-7.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:24500f4b0e03aab60ce575c85365beab64b44d4db837021e08339f61d1fbfe52", size = 206994, upload-time = "2024-10-09T11:31:59.205Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ee/57d607e14479fb760721ea1784608ade532665934bd75f260b250dc6c877/coverage-7.6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a663b180b6669c400b4630a24cc776f23a992d38ce7ae72ede2a397ce6b0f170", size = 235429, upload-time = "2024-10-09T11:32:00.967Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e1/cd263fd750fdb115aab11a086e3584d99d46fca1f201b5493cc3972aea28/coverage-7.6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfde025e2793a22efe8c21f807d276bd1d6a4bcc5ba6f19dbdfc4e7a12160909", size = 233329, upload-time = "2024-10-09T11:32:02.741Z" },
-    { url = "https://files.pythonhosted.org/packages/30/3b/a1623d50fcd6ba532cef0c3c1059eec2a08a311676ffa84dbe4beb2b8a33/coverage-7.6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:087932079c065d7b8ebadd3a0160656c55954144af6439886c8bcf78bbbcde7f", size = 234491, upload-time = "2024-10-09T11:32:03.804Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/a6/8f3b3fd1f9b9400f3df38a7159362622546e2d951cc4984cf4617d0fd4d7/coverage-7.6.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9c6b0c1cafd96213a0327cf680acb39f70e452caf8e9a25aeb05316db9c07f89", size = 233589, upload-time = "2024-10-09T11:32:04.877Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/40/37d64093f57b372435d87679956607ecab066d2aede76c6d215815a35fa3/coverage-7.6.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6e85830eed5b5263ffa0c62428e43cb844296f3b4461f09e4bdb0d44ec190bc2", size = 232050, upload-time = "2024-10-09T11:32:07.647Z" },
-    { url = "https://files.pythonhosted.org/packages/80/63/cbb76298b4f42bffe0030f1bc129a26a26255857c6beaa20419259ac07cc/coverage-7.6.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:62ab4231c01e156ece1b3a187c87173f31cbeee83a5e1f6dff17f288dca93345", size = 233180, upload-time = "2024-10-09T11:32:09.321Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/6a/eafa81503e905d473b799920927b06aa6ffba12db035fc98735b55bc1741/coverage-7.6.2-cp310-cp310-win32.whl", hash = "sha256:7b80fbb0da3aebde102a37ef0138aeedff45997e22f8962e5f16ae1742852676", size = 209281, upload-time = "2024-10-09T11:32:10.503Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d1/6b354c2cd52e0244944c097aaa71896869878df999f5f8e75fcd37eaf0f3/coverage-7.6.2-cp310-cp310-win_amd64.whl", hash = "sha256:d20c3d1f31f14d6962a4e2f549c21d31e670b90f777ef4171be540fb7fb70f02", size = 210092, upload-time = "2024-10-09T11:32:12.213Z" },
     { url = "https://files.pythonhosted.org/packages/a5/29/72da824da4182f518b054c21552b7ed2473a4e4c6ac616298209808a1a5c/coverage-7.6.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bb21bac7783c1bf6f4bbe68b1e0ff0d20e7e7732cfb7995bc8d96e23aa90fc7b", size = 206667, upload-time = "2024-10-09T11:32:13.409Z" },
     { url = "https://files.pythonhosted.org/packages/23/52/c15dcf3cf575256c7c0992e441cd41092a6c519d65abe1eb5567aab3d8e8/coverage-7.6.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a7b2e437fbd8fae5bc7716b9c7ff97aecc95f0b4d56e4ca08b3c8d8adcaadb84", size = 207111, upload-time = "2024-10-09T11:32:14.469Z" },
     { url = "https://files.pythonhosted.org/packages/92/61/0d46dc26cf9f711b7b6078a54680665a5c2d62ec15991adb51e79236c699/coverage-7.6.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:536f77f2bf5797983652d1d55f1a7272a29afcc89e3ae51caa99b2db4e89d658", size = 239050, upload-time = "2024-10-09T11:32:15.578Z" },
@@ -263,7 +222,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/8b/542b607d2cff56e5a90a6948f5a9040b693761d2be2d3c3bf88957b02361/coverage-7.6.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ff797320dcbff57caa6b2301c3913784a010e13b1f6cf4ab3f563f3c5e7919db", size = 247354, upload-time = "2024-10-09T11:33:09.719Z" },
     { url = "https://files.pythonhosted.org/packages/95/82/2e9111aa5e59f42b332d387f64e3205c2263518d1e660154d0c9fc54390e/coverage-7.6.2-cp313-cp313t-win32.whl", hash = "sha256:2b636a301e53964550e2f3094484fa5a96e699db318d65398cfba438c5c92171", size = 210194, upload-time = "2024-10-09T11:33:10.935Z" },
     { url = "https://files.pythonhosted.org/packages/9d/46/aabe4305cfc57cab4865f788ceceef746c422469720c32ed7a5b44e20f5e/coverage-7.6.2-cp313-cp313t-win_amd64.whl", hash = "sha256:d03a060ac1a08e10589c27d509bbdb35b65f2d7f3f8d81cf2fa199877c7bc58a", size = 211346, upload-time = "2024-10-09T11:33:12.889Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/5c/88f15b7614ba9ed1dbb1c0bd2c9073184b96c2bead0b93199487b44d04b3/coverage-7.6.2-pp39.pp310-none-any.whl", hash = "sha256:667952739daafe9616db19fbedbdb87917eee253ac4f31d70c7587f7ab531b4e", size = 198799, upload-time = "2024-10-09T11:33:28.796Z" },
 ]
 
 [package.optional-dependencies]
@@ -287,15 +245,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
 ]
 
 [[package]]
@@ -327,7 +276,6 @@ version = "6.114.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/03/1348ccb88bd3df1f1848afdea74c4c1dd42e75d1be9d022123d8f3cb180a/hypothesis-6.114.1.tar.gz", hash = "sha256:15ea6e4bb297276351ada18f172c60049c117a91040154ea620c632cc4c53e88", size = 407177, upload-time = "2024-10-10T08:49:11.931Z" }
@@ -351,18 +299,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304, upload-time = "2024-09-11T14:56:08.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514, upload-time = "2024-09-11T14:56:07.019Z" },
 ]
 
 [[package]]
@@ -431,16 +367,10 @@ version = "1.11.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/86/5d7cbc4974fd564550b80fbb8103c05501ea11aa7835edf3351d90095896/mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79", size = 3078806, upload-time = "2024-08-24T22:50:11.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/cd/815368cd83c3a31873e5e55b317551500b12f2d1d7549720632f32630333/mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a", size = 10939401, upload-time = "2024-08-24T22:49:18.929Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/27/e18c93a195d2fad75eb96e1f1cbc431842c332e8eba2e2b77eaf7313c6b7/mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef", size = 10111697, upload-time = "2024-08-24T22:49:32.504Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/08/cdc1fc6d0d5a67d354741344cc4aa7d53f7128902ebcbe699ddd4f15a61c/mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383", size = 12500508, upload-time = "2024-08-24T22:49:12.327Z" },
-    { url = "https://files.pythonhosted.org/packages/64/12/aad3af008c92c2d5d0720ea3b6674ba94a98cdb86888d389acdb5f218c30/mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8", size = 13020712, upload-time = "2024-08-24T22:49:49.399Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e6/a7d97cc124a565be5e9b7d5c2a6ebf082379ffba99646e4863ed5bbcb3c3/mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7", size = 9567319, upload-time = "2024-08-24T22:49:26.88Z" },
     { url = "https://files.pythonhosted.org/packages/e2/aa/cc56fb53ebe14c64f1fe91d32d838d6f4db948b9494e200d2f61b820b85d/mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385", size = 10859630, upload-time = "2024-08-24T22:49:51.895Z" },
     { url = "https://files.pythonhosted.org/packages/04/c8/b19a760fab491c22c51975cf74e3d253b8c8ce2be7afaa2490fbf95a8c59/mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca", size = 10037973, upload-time = "2024-08-24T22:49:21.428Z" },
     { url = "https://files.pythonhosted.org/packages/88/57/7e7e39f2619c8f74a22efb9a4c4eff32b09d3798335625a124436d121d89/mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104", size = 12416659, upload-time = "2024-08-24T22:49:35.02Z" },
@@ -584,11 +514,9 @@ version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487, upload-time = "2024-09-10T10:52:15.003Z" }
 wheels = [
@@ -614,15 +542,6 @@ version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
-    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
     { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
     { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
@@ -938,13 +857,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/06/d8cee5c3dfd550cc0a466ead8b321138198485d1034130ac1393cc49d63e/yamllint-1.35.1.tar.gz", hash = "sha256:7a003809f88324fd2c877734f2d575ee7881dd9043360657cc8049c809eba6cd", size = 134583, upload-time = "2024-02-16T10:50:18.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/28/2abf1ec14df2d584b9e7ce3b0be458838741e6aaff7a540374ba9af83916/yamllint-1.35.1-py3-none-any.whl", hash = "sha256:2e16e504bb129ff515b37823b472750b36b6de07963bd74b307341ef5ad8bdc3", size = 66738, upload-time = "2024-02-16T10:50:16.06Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.20.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199, upload-time = "2024-09-13T13:44:16.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200, upload-time = "2024-09-13T13:44:14.38Z" },
 ]


### PR DESCRIPTION
## Summary
- Replace the positional filename argument (which guessed `.py` vs `*.egg-info/PKG-INFO`) with mutually exclusive `--toml` and `--py` flags, and drop egg-info/PKG-INFO support entirely.
- Make `version` optional: its absence now means "just check the resolved source's PEP-440 compliance", replacing the old `--check-version-number-only` flag.
- `--toml` auto-detects `pyproject.toml`/`Cargo.toml` in the cwd with no value, or reads an explicit `file[:dotted.key.path]` otherwise (repeatable); if multiple sources resolve, all must agree.
- Bump minimum supported Python to 3.11+ to use stdlib `tomllib` rather than adding a `tomli` dependency (kept "no dependencies outside the standard library").
- Updated README (new usage/examples, Poetry example, `importlib.metadata.version(...)` guidance for implementing `__version__`), added `CONTEXT.md` glossary and an ADR recording the CLI redesign / Python floor trade-off.

This is a breaking CLI change — recommend a major version bump on release.

## Test plan
- [x] `pytest` — 54 tests, 100% coverage
- [x] `mypy`, `ruff check`, `ruff format --check`, `flake8` — all clean
- [x] `radon cc`/`complexipy` — all functions grade B or better
- [x] Manually smoke-tested every documented CLI scenario (compliance-only, `--toml` auto-detect single/match/mismatch, explicit `--toml=file:key.path`, `--py`, mutual-exclusivity error, nothing-given error) against real fixture files
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redesign the CLI to use explicit TOML and Python module version sources, removing PKG-INFO/egg-info support and making the positional version argument optional for compliance-only checks.

New Features:
- Add TOML-based version resolution with auto-detection of pyproject.toml/Cargo.toml and support for explicit file:key.path specifications.
- Add a Python module source flag to read versions from a module’s __version__ attribute, enabling explicit selection of comparison sources.

Enhancements:
- Rework version comparison logic to validate multiple sources for PEP-440 compliance and ensure all resolved versions agree, including mismatch reporting.
- Simplify the CLI interface around mutually exclusive --toml/--py flags and compliance-only mode, replacing the previous filename guessing and check-version-number-only flag.
- Improve error handling and messages for invalid versions, missing or malformed files, and configuration errors in version sources.

Build:
- Raise the minimum supported Python version to 3.11+ and update tooling configuration (e.g., Ruff target version) accordingly.

CI:
- Update CI workflows to test only on supported Python versions and to use the new --py flag in tag verification jobs.

Documentation:
- Update README usage and examples for the new CLI, Python module guidance via importlib.metadata.version, and TOML manifest workflows including Poetry.
- Add CONTEXT.md with a shared glossary of CLI concepts and version source terminology.
- Add an ADR documenting the CLI v2 redesign, dropped egg-info support, and the decision to raise the Python minimum version.

Tests:
- Expand and reorganize tests to cover TOML parsing, auto-detection, multiple-source resolution, compliance-only behavior, and the new CLI argument patterns while removing legacy PKG-INFO/egg-info tests.